### PR TITLE
regex match function not catching full dollar amount in  marketplace_price

### DIFF
--- a/wishlist/core.py
+++ b/wishlist/core.py
@@ -163,8 +163,8 @@ class WishlistElement(BaseAmazon):
         price = 0.0
         el = self.soup.find("span", {"class": "itemUsedAndNewPrice"})
         if el and len(el.contents) > 0:
-            match = re.match(".+(\d+\.\d+)", el.contents[0])
-            price = float(match.group(1)) if match else 0.0
+            match = re.findall("\d+\.\d+", el.contents[0])
+            price = float(match[0]) if match else 0.0
         return price
 
     @property


### PR DESCRIPTION
changed to regex.findall, removed grouping parenthesis and changed float cast to 0 index of returned list 